### PR TITLE
Handle errors while fetching releases from GitHub

### DIFF
--- a/nodejs/src/repo.js
+++ b/nodejs/src/repo.js
@@ -18,10 +18,9 @@ const octokit = new Octokit({
 const releaseUrl = process.argv[2];
 let [owner, repo] = releaseUrl.replace('github://', '').split('/');
 
-const repoData = {
+let repoData = {
     apiVersion: 'v1',
-    entries: {
-    }
+    entries: {}
 }
 
 async function getReleases() {
@@ -77,14 +76,14 @@ async function getReleases() {
                                     repoData.entries[chartName].push(releaseData);
                                 });
                             }
-
                         }
-
                     })
-
-
                 }
+            })
+            .catch((error) => {
+              console.error('Could not fetch page with releases. Error: ', error);
 
+              loadNextPage = false;
             });
     }
     process.stdout.write(yaml.safeDump(repoData));

--- a/nodejs/src/repo.js
+++ b/nodejs/src/repo.js
@@ -80,9 +80,9 @@ async function getReleases() {
                     })
                 }
             })
-            .catch((error) => {
-              console.error('Could not fetch page with releases. Error: ', error);
-
+            .catch((_error) => {
+              // Stop processing when GitHub throws an error on any page.
+              // Note: This could result in missing versions.
               loadNextPage = false;
             });
     }


### PR DESCRIPTION
- [x] Handle HTTP request errors when getting releases from repo

Before, such errors could appear. (Note: `...releases?page=11&per_page=100`)
```
[HttpError]: invalid json response body at https://api.github.com/repos/digando/infrastructure/releases?page=11&per_page=100 reason: Unexpected end of JSON input
    at /root/.local/share/helm/plugins/helm-github.git/src/repo.js:7:24405
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async /root/.local/share/helm/plugins/helm-github.git/src/repo.js:7:88020 {
  status: 500,
  request: {
    method: 'GET',
    url: 'https://api.github.com/repos/digando/infrastructure/releases?page=11&per_page=100',
    headers: {
      accept: 'application/vnd.github.v3+json',
      'user-agent': 'octokit-rest.js/18.12.0 octokit-core.js/3.5.1 Node.js/17.2.0 (linux; x64)',
      authorization: 'token [REDACTED]'
    },
    request: { hook: [Function: bound bound e] }
  }
}
``` 